### PR TITLE
bump to 2.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   daml:
     docker:
-      - image: digitalasset/daml-sdk:0.13.46
+      - image: digitalasset/daml-sdk:2.4.0
     steps:
       - checkout
       - setup_remote_docker

--- a/Readme.md
+++ b/Readme.md
@@ -11,12 +11,12 @@ If you are not familiar with the CDM already, we recommend to read the [document
 
 ## Prerequisites
 
-* [DAML SDK](https://daml.com/) for building the DAML code
+* [Daml SDK](https://daml.com/) for building the Daml code
 * [stack](https://docs.haskellstack.org/en/stable/README/) for building the Haskell code
 
 ## How to use
 
-The CDM Event Specification Module provides a set of pure (deterministic, side-effect-free with no IO) "builder" functions that can be used to build valid CDM events. The concept of a function exists in almost any program language - it takes some values as input and returns a result. The specification is written in [DAML](daml) and translated into other languages. Currently, [Haskell](haskell) is available.
+The CDM Event Specification Module provides a set of pure (deterministic, side-effect-free with no IO) "builder" functions that can be used to build valid CDM events. The concept of a function exists in almost any program language - it takes some values as input and returns a result. The specification is written in [Daml](daml) and translated into other languages. Currently, [Haskell](haskell) is available.
 
 
 ### Example: Termination
@@ -76,4 +76,4 @@ Traditionally, standards have focused on data representation only. The task of g
 
 **What is meant by specification?**
 
-Essentially, it's a reference implementation that can be translated into other languages. The specification is written in DAML and can directly be used in DAML applications. The important point is that it is also translated into other languages. Haskell is currently available but other languages like Java or C# will follow.
+Essentially, it's a reference implementation that can be translated into other languages. The specification is written in Daml and can directly be used in Daml applications. The important point is that it is also translated into other languages. Haskell is currently available but other languages like Java or C# will follow.

--- a/daml/Readme.md
+++ b/daml/Readme.md
@@ -1,3 +1,3 @@
-# How to use the DAML module
+# How to use the Daml module
 
-Given that the specification is written in DAML, it can be used as is if you are a DAML developer. Note that the module is not packaged into an own library currently. To use this library and its functions, copy the source code into your DAML application.
+Given that the specification is written in Daml, it can be used as is if you are a Daml developer. Note that the module is not packaged into an own library currently. To use this library and its functions, copy the source code into your Daml application.

--- a/daml/daml.yaml
+++ b/daml/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.46
+sdk-version: 2.4.0
 name: cdm-event-specification-module
 source: src
 version: 2.0.31.0
@@ -7,3 +7,4 @@ exposed-modules:
 dependencies:
 - daml-prim
 - daml-stdlib
+- daml-script

--- a/daml/src/Org/Isda/Cdm/Classes.daml
+++ b/daml/src/Org/Isda/Cdm/Classes.daml
@@ -1,4 +1,3 @@
-daml 1.2
 
 -- | This file is auto-generated from the ISDA Common
 --   Domain Model, do not edit.

--- a/daml/src/Org/Isda/Cdm/Enums.daml
+++ b/daml/src/Org/Isda/Cdm/Enums.daml
@@ -1,4 +1,3 @@
-daml 1.2
 
 -- | This file is auto-generated from the ISDA Common
 --   Domain Model, do not edit.

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule
   ( buildDerivedEvents
   , buildNewTradeEvent

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Auxiliary/Event.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Auxiliary/Event.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Auxiliary.Event where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Auxiliary/Netting.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Auxiliary/Netting.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Auxiliary.Netting where
 
 import DA.List

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Derived.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Derived.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.EventBuilder.Derived where
 
 import DA.List as L

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/NewTrade.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/NewTrade.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.EventBuilder.NewTrade where
 
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Event

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Novation.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Novation.daml
@@ -1,12 +1,11 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.EventBuilder.Novation where
 
 import DA.List
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract
-import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity
+import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity as CQ
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Event
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Identifier
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
@@ -94,7 +93,7 @@ buildQuantityChangePrimitive change closedState contract =
   let identifierNew = map increaseVersion contract.contractIdentifier
 
       quantity = getContractualQuantity contract
-      quantityNew = zipWith subtract quantity change
+      quantityNew = zipWith CQ.subtract quantity change
 
       afterContract = (setContractualQuantity quantityNew contract)
                         { contractIdentifier = identifierNew

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Termination.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/EventBuilder/Termination.daml
@@ -1,11 +1,10 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.EventBuilder.Termination where
 
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract
-import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity
+import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity as CQ
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Event
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Identifier
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
@@ -80,7 +79,7 @@ buildQuantityChangePrimitive change closedState contract =
   let identifierNew = map increaseVersion contract.contractIdentifier
 
       quantity = getContractualQuantity contract
-      quantityNew = zipWith subtract quantity change
+      quantityNew = zipWith CQ.subtract quantity change
 
       afterContract = (setContractualQuantity quantityNew contract)
                         { contractIdentifier = identifierNew

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract where
 
 import DA.List as L
@@ -33,9 +32,8 @@ getContractualQuantity contract =
   in case payout.creditDefaultPayout of
       Some cdp ->
         let cdpQuantities = map getCdpQuantity cdp.protectionTerms
-            irpQuantities = map (fromOptional cdpQuantity . getIrpQuantity) payout.interestRatePayout
-
             cdpQuantity = getFirst "protectionTerms" cdpQuantities
+            irpQuantities = map (fromOptional cdpQuantity . getIrpQuantity) payout.interestRatePayout
         in if any (/= cdpQuantity) cdpQuantities || any (/= cdpQuantity) irpQuantities
             then throwNotSupportedError "non-unique quantity"
             else [cdpQuantity]

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout
   ( checkPayout
   , buildEvents

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/Cashflow.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/Cashflow.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.Cashflow
   ( buildEvent
   ) where

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/ContractualQuantity.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/ContractualQuantity.daml
@@ -1,11 +1,10 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity
   ( getCurrency
   , calcQuantity
-  , subtract
+  , Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity.subtract
   )
   where
 

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout
   ( buildEvents
   ) where

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/FloatingRate.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/FloatingRate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout.FloatingRate where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/PaymentCalculationPeriod.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/PaymentCalculationPeriod.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout.PaymentCalculationPeriod where
 
 import DA.List as L

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/CalculationPeriodDates.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/CalculationPeriodDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout.Schedule.CalculationPeriodDates
   ( generateCalculationPeriods
   ) where

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/PaymentDates.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/PaymentDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout.Schedule.PaymentDates
   ( generatePaymentCalculationPeriods
   )  where

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/ResetDates.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Contract/Payout/InterestRatePayout/Schedule/ResetDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePayout.Schedule.ResetDates where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableDate.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableDate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.AdjustableDate where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableOrAdjustedOrRelativeDate.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableOrAdjustedOrRelativeDate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.AdjustableOrAdjustedOrRelativeDate where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableOrRelativeDate.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/AdjustableOrRelativeDate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.AdjustableOrRelativeDate where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Base.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Base.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Base where
 
 import DA.Date as D

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/BusinessCenters.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/BusinessCenters.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.BusinessCenters where
 
 import DA.List

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/BusinessDayAdjustments.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/BusinessDayAdjustments.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.BusinessDayAdjustments where
 
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Base

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/DayCountFraction.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/DayCountFraction.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.DayCountFraction (calcDayCountFraction) where
 
 import DA.Date

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Offset.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Offset.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Offset where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Period.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/Period.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Period where
 
 import DA.Date

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/RollConvention.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Date/RollConvention.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Date.RollConvention
   ( nextDate
   , previousDate

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Event.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Event.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Event where
 
 import DA.Date as D

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Event/Transfer.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Event/Transfer.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Event.Transfer where
 
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Identifier.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Identifier.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Identifier where
 
 import DA.Optional

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Utils.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Impl/Utils.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Impl.Utils where
 
 import DA.List

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/All.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/All.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.All
   ( module Org.Isda.Cdm.Classes
   , module Org.Isda.Cdm.Enums

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/EventSpec.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/EventSpec.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.EventSpec where
 
 import Org.Isda.Cdm.Classes

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Fetch.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Fetch.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.Fetch where
 
 import Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.HolidayCalendar

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/HolidayCalendar.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/HolidayCalendar.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.HolidayCalendar where
 
 import Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.Key

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Key.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Key.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.Key where
 
 -- | A class for types that have a corresponding key.

--- a/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Observation.daml
+++ b/daml/src/Org/Isda/Cdm/EventSpecificationModule/Types/ReferenceData/Observation.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.Observation where
 
 import Org.Isda.Cdm.Classes

--- a/daml/src/Org/Isda/Cdm/MetaClasses.daml
+++ b/daml/src/Org/Isda/Cdm/MetaClasses.daml
@@ -1,4 +1,3 @@
-daml 1.2
 
 -- | This file is auto-generated from the ISDA Common
 --   Domain Model, do not edit.

--- a/daml/src/Org/Isda/Cdm/MetaFields.daml
+++ b/daml/src/Org/Isda/Cdm/MetaFields.daml
@@ -1,4 +1,3 @@
-daml 1.2
 
 -- | This file is auto-generated from the ISDA Common
 --   Domain Model, do not edit.

--- a/daml/src/Org/Isda/Cdm/ZonedDateTime.daml
+++ b/daml/src/Org/Isda/Cdm/ZonedDateTime.daml
@@ -1,4 +1,3 @@
-daml 1.2
 
 -- | This file is auto-generated from the ISDA Common
 --   Domain Model, do not edit.

--- a/daml/src/Test/Date/AdjustableDate.daml
+++ b/daml/src/Test/Date/AdjustableDate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.AdjustableDate where
 
 import DA.Assert
@@ -10,8 +9,9 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.AdjustableDate
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.ReferenceData()
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let ad = AdjustableDate {
             id = None,
             adjustedDate = None,

--- a/daml/src/Test/Date/Base.daml
+++ b/daml/src/Test/Date/Base.daml
@@ -1,15 +1,15 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.Base where
 
 import DA.Assert
 import DA.Date
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Base
 import Org.Isda.Cdm.EventSpecificationModule.Types.ReferenceData.HolidayCalendar
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let hc = HolidayCalendarData { label = "USNY", weekend = [Saturday, Sunday], holidays = [date 2018 Jan 02, date 2018 Jan 31, date 2018 Feb 1] }
 
   isHoliday hc (date 2018 Jan 02) === True

--- a/daml/src/Test/Date/BusinessDayAdjustments.daml
+++ b/daml/src/Test/Date/BusinessDayAdjustments.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.BusinessDayAdjustments where
 
 import DA.Assert
@@ -10,8 +9,9 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.BusinessDayAdjustments
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.ReferenceData()
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let bcs = BusinessCenters { businessCenter = [fieldWithEmptyMeta BusinessCenterEnum_USNY], businessCentersReference = None, id = None }
 
   let adjNone = BusinessDayAdjustments {businessCenters = Some bcs, businessDayConvention = BusinessDayConventionEnum_NONE, id = None}

--- a/daml/src/Test/Date/DayCountFraction.daml
+++ b/daml/src/Test/Date/DayCountFraction.daml
@@ -1,13 +1,13 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.DayCountFraction where
 
 import DA.Assert
 import DA.Date as D
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.DayCountFraction
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   calcDayCountFraction DayCountFractionEnum__30E_360 (D.date 2018 Feb 28) (D.date 2018 May 30) === (intToDecimal 92 / 360.0)

--- a/daml/src/Test/Date/Offset.daml
+++ b/daml/src/Test/Date/Offset.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.Offset where
 
 import DA.Assert
@@ -10,8 +9,9 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Offset
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.ReferenceData()
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let o1 = Offset { dayType = None, period = PeriodEnum_Y, periodMultiplier = 1, id = None }
   res <- applyOffset o1 None (D.date 2017 Dec 31)
   res === (D.date 2018 Dec 31)

--- a/daml/src/Test/Date/Period.daml
+++ b/daml/src/Test/Date/Period.daml
@@ -1,15 +1,15 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.Period where
 
 import DA.Assert
 import DA.Date as D
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.Period
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   (addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = PeriodEnum_D, id = None}) === D.date 2018 Oct 02)
   (addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = PeriodEnum_W, id = None}) === D.date 2018 Oct 08)
   (addPeriod (D.date 2018 Oct 01) (Period {periodMultiplier = 1, period = PeriodEnum_M, id = None}) === D.date 2018 Nov 01)

--- a/daml/src/Test/Date/RollConvention.daml
+++ b/daml/src/Test/Date/RollConvention.daml
@@ -1,15 +1,15 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Date.RollConvention where
 
 import DA.Assert
 import DA.Date as D
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Date.RollConvention
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
+import Daml.Script (script)
 
-testNextDate = scenario do
+testNextDate = script do
   nextDate RollConventionEnum_EOM (Period {periodMultiplier = 1, period = PeriodEnum_M, id = None}) (D.date 2018 Oct 31) === (D.date 2018 Nov 30)
   nextDate RollConventionEnum__1  (Period {periodMultiplier = 1, period = PeriodEnum_M, id = None}) (D.date 2018 Oct 01) === (D.date 2018 Nov 01)
   nextDate RollConventionEnum__30 (Period {periodMultiplier = 3, period = PeriodEnum_M, id = None}) (D.date 2018 Feb 28) === (D.date 2018 May 30)
@@ -17,11 +17,11 @@ testNextDate = scenario do
   nextDate RollConventionEnum_EOM (Period {periodMultiplier = 2, period = PeriodEnum_M, id = None}) (D.date 2018 Feb 28) === (D.date 2018 Apr 30)
   nextDate RollConventionEnum__30 (Period {periodMultiplier = 3, period = PeriodEnum_M, id = None}) (D.date 2018 Nov 30) === (D.date 2019 Feb 28)
 
-testImplyRollConvention = scenario do
+testImplyRollConvention = script do
   implyRollConvention False (D.date 2018 Jan 1) === RollConventionEnum__1
   implyRollConvention False (D.date 2018 Feb 28) === RollConventionEnum__28
   implyRollConvention True (D.date 2018 Feb 28) === RollConventionEnum_EOM
 
-main = scenario do
+main = script do
   testNextDate
   testImplyRollConvention

--- a/daml/src/Test/EventBuilder/Derived.daml
+++ b/daml/src/Test/EventBuilder/Derived.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.EventBuilder.Derived where
 
 import DA.Assert
@@ -9,8 +8,9 @@ import DA.List as L
 import Org.Isda.Cdm.EventSpecificationModule
 import Test.Examples
 import Test.ReferenceData
+import Daml.Script (script)
 
-cds_all_periods = scenario do
+cds_all_periods = script do
   let spec = DerivedSpec
         { fromDate = None
         , toDate = None
@@ -22,7 +22,7 @@ cds_all_periods = scenario do
 
   return events
 
-cds_last_period = scenario do
+cds_last_period = script do
   eventsAll <- cds_all_periods
 
   let spec = DerivedSpec

--- a/daml/src/Test/EventBuilder/Termination.daml
+++ b/daml/src/Test/EventBuilder/Termination.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.EventBuilder.Termination where
 
 import DA.Date as D
@@ -9,8 +8,9 @@ import DA.Time as T
 import Org.Isda.Cdm.EventSpecificationModule
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Test.Examples
+import Daml.Script (script)
 
-termination = scenario do
+termination = script do
   let baseEvent = BaseEvent
         { account = []
         , action = ActionEnum_New
@@ -52,7 +52,7 @@ termination = scenario do
   let terminationEvent = buildTerminationEvent spec
   return terminationEvent
 
-partialTermination = scenario do
+partialTermination = script do
   let baseEvent = BaseEvent
         { account = []
         , action = ActionEnum_New

--- a/daml/src/Test/Examples.daml
+++ b/daml/src/Test/Examples.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Examples where
 
 import DA.Date as D

--- a/daml/src/Test/Impl/Payout.daml
+++ b/daml/src/Test/Impl/Payout.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout where
 
 import DA.Assert
@@ -14,6 +13,7 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Event
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.Examples
 import Test.ReferenceData()
+import Daml.Script (script)
 
 genPayment : Decimal -> Date -> Optional Date -> Optional CashflowTypeEnum -> TransferPrimitive
 genPayment amount unadjustedDate adjustedDate cfType =
@@ -56,7 +56,7 @@ genPayment amount unadjustedDate adjustedDate cfType =
     rosettaKey = ""
  }
 
-testBasisSwap = scenario do
+testBasisSwap = script do
   -- Calculate Events
   let reset1M_1 = ResetPrimitive { date = D.date 2018 Nov 30, resetValue = 0.01, cashflow = None }
   let payment1M_1 = genPayment 2499.999999 (D.date 2018 Dec 31) (Some $ D.date 2018 Dec 31) (Some CashflowTypeEnum_Interest)
@@ -112,7 +112,7 @@ testBasisSwap = scenario do
   map (\p -> p.primitive) res               === expectedP
 
 
-testCDS = scenario do
+testCDS = script do
   let expectedED = [D.date 2018 Nov 15, D.date 2018 Dec 19, D.date 2019 Mar 19, D.date 2019 Jun 19, D.date 2019 Sep 19, D.date 2019 Dec 20]
   let expectedQ  = ["CashTransfer", "CashTransfer", "CashTransfer", "CashTransfer", "CashTransfer", "CashTransfer"]
   let expectedL  =
@@ -141,6 +141,6 @@ testCDS = scenario do
   map (\p -> p.primitive) res                 === expectedP
 
 
-main = scenario do
+main = script do
   testBasisSwap
   testCDS

--- a/daml/src/Test/Impl/Payout/Cashflow.daml
+++ b/daml/src/Test/Impl/Payout/Cashflow.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.Cashflow where
 
 import DA.Assert
@@ -13,8 +12,9 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All
 import Test.Examples
 import Test.ReferenceData()
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let payment = TransferPrimitive {
                   cashTransfer =
                     [ CashTransferComponent {

--- a/daml/src/Test/Impl/Payout/ContractualQuantity.daml
+++ b/daml/src/Test/Impl/Payout/ContractualQuantity.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.ContractualQuantity where
 
 import DA.Assert
@@ -9,8 +8,9 @@ import DA.Date as D
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.ContractualQuantity
 import Test.Examples
 import Test.ReferenceData()
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   let quantity = calcQuantity (D.date 1900 Jan 01) cq1m
   quantity === (Some 1000000.0, None)
   getCurrency cq1m === "USD"

--- a/daml/src/Test/Impl/Payout/InterestRatePayout.daml
+++ b/daml/src/Test/Impl/Payout/InterestRatePayout.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.InterestRatePayout where
 
 import DA.Assert
@@ -14,6 +13,7 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.Examples
 import Test.ReferenceData()
+import Daml.Script (script)
 
 genPayment : Decimal -> Date -> Date -> TransferPrimitive
 genPayment amount unadjustedDate adjustedDate =
@@ -66,7 +66,7 @@ genPayment amount unadjustedDate adjustedDate =
     rosettaKey = ""
   }
 
-testFloating = scenario do
+testFloating = script do
   let irp = irpFloating3M { rosettaKey = "Test" } : InterestRatePayout
   let payment1 = genPayment 2916.666669 (D.date 2018 Dec 5) (D.date 2018 Dec 5)
   let reset2 = ResetPrimitive { date = D.date 2018 Nov 30, resetValue = 0.03, cashflow = None }
@@ -118,7 +118,7 @@ testFloating = scenario do
   mapOptional (\r -> r.lineage) res         === tail expectedL
   map (\p -> p.primitive) res               === tail expectedP
 
-testFixed = scenario do
+testFixed = script do
   let expectedP =
         [ emptyPrimitiveEvent { transfer = [genPayment 833.333334 (D.date 2018 Dec 5) (D.date 2018 Dec 5)] } : PrimitiveEvent
         , emptyPrimitiveEvent { transfer = [genPayment 4888.888888 (D.date 2019 Mar 5) (D.date 2019 Mar 5)] } : PrimitiveEvent
@@ -132,6 +132,6 @@ testFixed = scenario do
 
   map (\p -> p.primitive) res === expectedP
 
-main = scenario do
+main = script do
   testFloating
   testFixed

--- a/daml/src/Test/Impl/Payout/InterestRatePayout/FloatingRate.daml
+++ b/daml/src/Test/Impl/Payout/InterestRatePayout/FloatingRate.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.InterestRatePayout.FloatingRate where
 
 import DA.Assert
@@ -13,6 +12,7 @@ import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.Examples
 import Test.ReferenceData()
 import Test.Impl.Payout.InterestRatePayout.Schedule.ResetDates
+import Daml.Script (script)
 
 testCaseFrd0 : FloatingRateDefinition
 testCaseFrd0 = emptyFloatingRateDefinition {
@@ -34,11 +34,11 @@ testCaseFrd1 = emptyFloatingRateDefinition {
                   ]
                }
 
-testImplyInitialReset = scenario do
+testImplyInitialReset = script do
   let expectedResult = ResetPrimitive { date = D.date 2018 Nov 30, resetValue = 0.03, cashflow = None }
   getInitialReset 0.03 testCaseFrd1 === expectedResult
 
-testGenerateResets = scenario do
+testGenerateResets = script do
   -- reset does not exist
   res <- buildResetEvents None None emptyLineage [] frc3M testCaseFrd0
   map (\r -> r.eventDate) res             === [D.date 2018 Nov 24]
@@ -56,7 +56,7 @@ testGenerateResets = scenario do
   res <- buildResetEvents None None emptyLineage [reset] frc3M testCaseFrd1
   map (\r -> r.eventDate) res === []
 
-testCalcFloatingRate = scenario do
+testCalcFloatingRate = script do
   -- Reset does not exist
   let resets = []
   let expectedResult = emptyFloatingRateDefinition {
@@ -89,7 +89,7 @@ testCalcFloatingRate = scenario do
   let res = calcFloatingRate resets frc3M testCaseFrd1
   res === expectedResult
 
-main = scenario do
+main = script do
   testImplyInitialReset
   testGenerateResets
   testCalcFloatingRate

--- a/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/CalculationPeriodDates.daml
+++ b/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/CalculationPeriodDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.InterestRatePayout.Schedule.CalculationPeriodDates where
 
 import DA.Assert
@@ -11,6 +10,7 @@ import Org.Isda.Cdm.EventSpecificationModule.Impl.Contract.Payout.InterestRatePa
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.Examples
 import Test.ReferenceData()
+import Daml.Script (script)
 
 emptyCalculationPeriod : CalculationPeriod
 emptyCalculationPeriod = CalculationPeriod {
@@ -42,7 +42,7 @@ setStubType : StubPeriodTypeEnum -> CalculationPeriodDates -> CalculationPeriodD
 setStubType stubType calcPeriodDates =
   calcPeriodDates { stubPeriodType = Some stubType }
 
-main = scenario do
+main = script do
   -- Explicit stubs
   let expectedResultBothStub =
         [ emptyCalculationPeriod {

--- a/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/PaymentDates.daml
+++ b/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/PaymentDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.InterestRatePayout.Schedule.PaymentDates where
 
 import DA.Assert
@@ -12,6 +11,7 @@ import Test.Examples
 import Test.ReferenceData()
 import Test.Impl.Payout.InterestRatePayout.Schedule.CalculationPeriodDates
 import Test.Impl.Payout.InterestRatePayout.Schedule.ResetDates
+import Daml.Script (script)
 
 emptyPaymentCalculationPeriod : PaymentCalculationPeriod
 emptyPaymentCalculationPeriod = PaymentCalculationPeriod {
@@ -156,6 +156,6 @@ expectedResultPcps =
     }
   ]
 
-main = scenario do
+main = script do
   res <- generatePaymentCalculationPeriods cpdsBothStub3M (Some rds3M) (Some pds3M)
   res === expectedResultPcps

--- a/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/ResetDates.daml
+++ b/daml/src/Test/Impl/Payout/InterestRatePayout/Schedule/ResetDates.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Impl.Payout.InterestRatePayout.Schedule.ResetDates where
 
 import DA.Assert
@@ -11,6 +10,7 @@ import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
 import Test.Examples
 import Test.ReferenceData()
 import Test.Impl.Payout.InterestRatePayout.Schedule.CalculationPeriodDates
+import Daml.Script (script)
 
 emptyFloatingRateDefinition : FloatingRateDefinition
 emptyFloatingRateDefinition = FloatingRateDefinition {
@@ -35,7 +35,7 @@ emptyRateObservation = RateObservation {
                         treatedRate = None
                       }
 
-main = scenario do
+main = script do
   let expectedResult =
         [ emptyCalculationPeriod {
             unadjustedStartDate = Some $ D.date 2018 Nov 15,

--- a/daml/src/Test/Main.daml
+++ b/daml/src/Test/Main.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.Main where
 
 import Test.Date.AdjustableDate
@@ -19,8 +18,9 @@ import Test.Impl.Payout
 import Test.Impl.Payout.InterestRatePayout.Schedule.CalculationPeriodDates
 import Test.Impl.Payout.InterestRatePayout.Schedule.PaymentDates
 import Test.Impl.Payout.InterestRatePayout.Schedule.ResetDates
+import Daml.Script (script)
 
-main = scenario do
+main = script do
   Test.Date.AdjustableDate.main
   Test.Date.Base.main
   Test.Date.BusinessDayAdjustments.main

--- a/daml/src/Test/ReferenceData.daml
+++ b/daml/src/Test/ReferenceData.daml
@@ -1,14 +1,14 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module Test.ReferenceData where
 
 import DA.Date as D
 import Org.Isda.Cdm.EventSpecificationModule.Impl.Utils
 import Org.Isda.Cdm.EventSpecificationModule.Types.All hiding (length)
+import Daml.Script (Script)
 
-instance Fetch Scenario where
+instance Fetch Script where
   fetchHolidayCalendar key = return $ fmap snd $ find ((== key) . fst) cals
   fetchObservation key = return $ fmap snd $ find ((== key) . fst) obs
 

--- a/haskell/libs/daml-stdlib/src/DA/Assert.hs
+++ b/haskell/libs/daml-stdlib/src/DA/Assert.hs
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module DA.Assert
-  ( scenario
+  ( script
   , (===)
   , describe
   ) where
@@ -13,8 +13,8 @@ import "base" Control.Exception
 import Data.Text (Text)
 import Test.Hspec
 
-scenario :: String -> Expectation -> SpecWith ()
-scenario = it
+script :: String -> Expectation -> SpecWith ()
+script = it
 
 (===) :: (HasCallStack, Eq a, Show a) => a -> a -> Expectation
 (===) = shouldBe

--- a/haskell/libs/daml-stdlib/src/Prelude.hs
+++ b/haskell/libs/daml-stdlib/src/Prelude.hs
@@ -26,8 +26,8 @@ module Prelude
     , find
     , length
 
-    , Scenario
-    , scenario
+    , Script
+    , script
     , describe
     ) where
 
@@ -114,4 +114,4 @@ return = pure
 mapA :: (Applicative f, Traversable t) => (a -> f b) -> t a -> f (t b)
 mapA = traverse
 
-type Scenario = IO
+type Script = IO

--- a/haskell/scripts/preprocess.sh
+++ b/haskell/scripts/preprocess.sh
@@ -14,10 +14,10 @@ rm "$HS_FILE.bak"
 MODULE_NAME="${HS_FILE#haskell/test/}"
 MODULE_NAME="${MODULE_NAME%.hs}"
 MODULE_NAME="${MODULE_NAME////.}"
-if grep 'scenario' "$HS_FILE" | grep -q -v "main" || [[ "$HS_FILE" == *Main.hs ]]; then
-    sed -i.bak "s|main = scenario|main = describe \"${MODULE_NAME}\"|" "$HS_FILE"
+if grep 'script' "$HS_FILE" | grep -q -v "main" || [[ "$HS_FILE" == *Main.hs ]]; then
+    sed -i.bak "s|main = script|main = describe \"${MODULE_NAME}\"|" "$HS_FILE"
 else
-    sed -i.bak "s|main = scenario|main = scenario \"${MODULE_NAME}\"|" "$HS_FILE"
+    sed -i.bak "s|main = script|main = script \"${MODULE_NAME}\"|" "$HS_FILE"
 fi
 rm "$HS_FILE".bak
 stack exec --stack-yaml haskell/libs/with-preprocessor/stack.yaml with-preprocessor "$HS_FILE" "$HS_FILE"

--- a/haskell/scripts/replace.sed
+++ b/haskell/scripts/replace.sed
@@ -3,11 +3,13 @@
 
 # Delete version headers
 /daml 1\.2/d
+# Delete Script import
+/import Daml.Script/d
 # Swap type signatures and cons using ~~ as an intermediate substitution
 s/::/~~/g
 s/:/::/g
 s/~~/:/g
 # Replace with-syntax wildcards
 s/with \.\./{\.\.}/
-/^main =/!s/\(.*\) = scenario/\1 = scenario "\1"/
+/^main =/!s/\(.*\) = script/\1 = script "\1"/
 /ActionEnum/!s/Action/Monad/


### PR DESCRIPTION
Since this is a "pure functions" library, the upgrade process is fairly straightforward. Changes:

- Remove all of the "daml 1.2" headers
- Switch from scenario to script
- `subtract` was added to Prelude
- `let` bindings ordering is now strict